### PR TITLE
A 'kill-connection' should complete, not error, connection-based streams

### DIFF
--- a/library/coverage.gradle
+++ b/library/coverage.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'jacoco'
 
 jacoco {
-    toolVersion = "0.7.9"
+    toolVersion = "0.8.0"
 }
 
 // change the buildType and productFlavor fields here if the project uses different build variant for testing

--- a/library/src/main/kotlin/io/intrepid/bleidiom/BleIdiomImpl.kt
+++ b/library/src/main/kotlin/io/intrepid/bleidiom/BleIdiomImpl.kt
@@ -194,7 +194,7 @@ internal class BleCharValueDelegate<Val : Any>() : BleCharHandlerDSL<Val> {
                             .toRx2()
                             .map { byteArray -> transform(byteArray) }
                             .doOnNext { backingField.currentValue = it }
-                }
+                }.takeUntil(service!!.killedConnectionObs)
             } ?: Observable.error(IllegalStateException("observeAction is null"))
         }
 

--- a/library/src/main/kotlin/io/intrepid/bleidiom/BleIdiomService.kt
+++ b/library/src/main/kotlin/io/intrepid/bleidiom/BleIdiomService.kt
@@ -119,6 +119,8 @@ open class BleService<Svc : BleService<Svc>> : BleConfigureDSL<Svc> {
 
     internal val sharedConnection get() = device.sharedConnection
 
+    internal val killedConnectionObs get() = device.killedConnectionObs
+
     private val subscriptionsContainer = CompositeDisposable()
 
     /**
@@ -169,7 +171,7 @@ open class BleService<Svc : BleService<Svc>> : BleConfigureDSL<Svc> {
     /**
      * Forces a disconnect not only from this service but from the remote BLE device itself.
      * Note that this will cause any other Observers that are using connections to the remote
-     * BLE device to terminate.
+     * BLE device to terminate (the observers' 'onComplete()' will be called).
      */
     fun killCurrentConnection() = device.killCurrentConnection()
 


### PR DESCRIPTION
When a BleService call `killConnection`, Rx streams based on connections
should not produce an error but just complete instead.

Also, the code-coverage config has been updated to use JaCoCo 0.8.0