### PR TITLE
Connection fixes, hopefully

### DIFF
--- a/library/src/main/kotlin/io/intrepid/bleidiom/test/TestModules.kt
+++ b/library/src/main/kotlin/io/intrepid/bleidiom/test/TestModules.kt
@@ -1,7 +1,6 @@
 package io.intrepid.bleidiom.test
 
 import android.app.Application
-import android.bluetooth.BluetoothGattCharacteristic
 import android.content.Context
 import com.github.salomonbrys.kodein.Kodein
 import com.github.salomonbrys.kodein.bind
@@ -14,31 +13,20 @@ import com.github.salomonbrys.kodein.provider
 import com.github.salomonbrys.kodein.scopedSingleton
 import com.github.salomonbrys.kodein.singleton
 import com.github.salomonbrys.kodein.with
-import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.doAnswer
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.spy
-import com.nhaarman.mockito_kotlin.whenever
-import com.polidea.rxandroidble.internal.connection.NoRetryStrategy
 import com.polidea.rxandroidble2.RxBleClient
-import com.polidea.rxandroidble2.RxBleConnection
 import com.polidea.rxandroidble2.RxBleDevice
-import com.polidea.rxandroidble2.internal.connection.ImmediateSerializedBatchAckStrategy
 import com.polidea.rxandroidble2.mockrxandroidble.RxBleClientMock
 import com.polidea.rxandroidble2.mockrxandroidble.RxBleDeviceMock
 import io.intrepid.bleidiom.BleIdiomDevice
-import io.intrepid.bleidiom.letMany
 import io.intrepid.bleidiom.log.Logger
 import io.intrepid.bleidiom.module.LibKodein
 import io.intrepid.bleidiom.module.PublicBleModule
 import io.intrepid.bleidiom.module.initBleIdiomModules
 import io.reactivex.Observable
 import io.reactivex.Scheduler
-import io.reactivex.functions.BiFunction
 import io.reactivex.schedulers.TestScheduler
-import java.util.UUID
-import java.util.concurrent.atomic.AtomicInteger
-import kotlin.math.min
 
 @Suppress("PropertyName")
 val LibTestKodein: Kodein
@@ -80,22 +68,8 @@ class BleTestModules {
             bind<Scheduler>() with scopedSingleton(TestScope) { with(testClass).instance<TestScheduler>() }
 
             bind<RxBleDeviceMock>() with multiton { macAddress: String ->
-                val spiedDevice = spy(with(macAddress).instance<RxBleDevice>() as RxBleDeviceMock)
-                createMockedLongWriteBuilder(spiedDevice)
+                spy(with(macAddress).instance<RxBleDevice>() as RxBleDeviceMock)
             }
-        }
-
-        private fun createMockedLongWriteBuilder(spiedDevice: RxBleDeviceMock): RxBleDeviceMock {
-            doAnswer { inv ->
-                @Suppress("UNCHECKED_CAST")
-                val spiedConnection = inv.callRealMethod() as Observable<RxBleConnection>
-                spiedConnection.map {
-                    val spiedConn = spy(it)
-                    doAnswer { TestLongWriteBuilder(spiedConn) }.whenever(spiedConn).createNewLongWriteBuilder()
-                    spiedConn
-                }
-            }.whenever(spiedDevice).establishConnection(any())
-            return spiedDevice
         }
 
         private val BleModuleOverrides = Kodein.Module(allowSilentOverride = true) {
@@ -125,81 +99,3 @@ internal object TestScope : Scope<Any> {
     }
 }
 
-private class TestLongWriteBuilder(private val connection: RxBleConnection) : RxBleConnection.LongWriteOperationBuilder {
-
-    private var bluetoothGattCharacteristicObservable: Observable<BluetoothGattCharacteristic>? = null
-
-    private var maxBatchSize = 20 // default
-
-    private var bytes: ByteArray? = null
-
-    private var writeOperationAckStrategy: RxBleConnection.WriteOperationAckStrategy = ImmediateSerializedBatchAckStrategy()// default
-
-    private var writeOperationRetryStrategy: RxBleConnection.WriteOperationRetryStrategy = NoRetryStrategy()// default
-
-    override fun setWriteOperationRetryStrategy(writeOperationRetryStrategy: RxBleConnection.WriteOperationRetryStrategy): RxBleConnection.LongWriteOperationBuilder {
-        this.writeOperationRetryStrategy = writeOperationRetryStrategy
-        return this
-    }
-
-    override fun setBytes(bytes: ByteArray): RxBleConnection.LongWriteOperationBuilder {
-        this.bytes = bytes
-        return this
-    }
-
-    override fun setCharacteristicUuid(uuid: UUID): RxBleConnection.LongWriteOperationBuilder {
-        bluetoothGattCharacteristicObservable = connection.discoverServices()
-            .flatMap({ rxBleDeviceServices -> rxBleDeviceServices.getCharacteristic(uuid) })
-            .toObservable()
-        return this
-    }
-
-    override fun setCharacteristic(
-        bluetoothGattCharacteristic: BluetoothGattCharacteristic): RxBleConnection.LongWriteOperationBuilder {
-        bluetoothGattCharacteristicObservable = Observable.just(bluetoothGattCharacteristic)
-        return this
-    }
-
-    override fun setMaxBatchSize(maxBatchSize: Int): RxBleConnection.LongWriteOperationBuilder {
-        this.maxBatchSize = maxBatchSize
-        return this
-    }
-
-    override fun setWriteOperationAckStrategy(writeOperationAckStrategy: RxBleConnection.WriteOperationAckStrategy): RxBleConnection.LongWriteOperationBuilder {
-        this.writeOperationAckStrategy = writeOperationAckStrategy
-        return this
-    }
-
-    override fun build(): Observable<ByteArray> {
-        if (bluetoothGattCharacteristicObservable == null) {
-            throw IllegalArgumentException("setCharacteristicUuid() or setCharacteristic() needs to be called before build()")
-        }
-
-        if (bytes == null) {
-            throw IllegalArgumentException("setBytes() needs to be called before build()")
-        }
-
-        return letMany(bluetoothGattCharacteristicObservable, bytes) { bleGattCharObs, bytes ->
-            val excess = bytes.size % maxBatchSize > 0
-            val numberOfBatches = bytes.size / maxBatchSize + if (excess) 1 else 0
-            val numberOfBatchesLeft = AtomicInteger(numberOfBatches)
-
-            val batchObs = Observable.fromCallable { numberOfBatchesLeft.get() }
-            Observable.zip(batchObs, bleGattCharObs,
-                    BiFunction { chunkIdx: Int, char: BluetoothGattCharacteristic -> (chunkIdx to char) })
-                    .concatMap { (idx, char) ->
-                        val start = maxBatchSize * (numberOfBatches - idx)
-                        val end = min(start + maxBatchSize, bytes.size)
-                        connection
-                                .writeCharacteristic(char, bytes.sliceArray(start until end))
-                                .toObservable()
-                                .concatMap { Observable.just(idx) }
-                    }
-                    .map { idx -> idx > 0 }
-                    .compose(writeOperationAckStrategy)
-                    .repeatWhen { it.takeWhile { numberOfBatchesLeft.decrementAndGet() > 0 } }
-                    .toList()
-                    .flatMapObservable { Observable.just(bytes) }
-        } ?: Observable.empty()
-    }
-}

--- a/library/src/main/kotlin/io/intrepid/bleidiom/util/ReplayingUnfinalizedShare.kt
+++ b/library/src/main/kotlin/io/intrepid/bleidiom/util/ReplayingUnfinalizedShare.kt
@@ -1,0 +1,153 @@
+package io.intrepid.bleidiom.util
+
+import io.reactivex.Flowable
+import io.reactivex.FlowableTransformer
+import io.reactivex.Observable
+import io.reactivex.ObservableTransformer
+import io.reactivex.Observer
+import io.reactivex.disposables.Disposable
+import io.reactivex.functions.Action
+import io.reactivex.functions.Consumer
+import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
+
+/**
+ * A transformer which combines the `replay(1)`, `publish()`, and `refCount()`
+ * operators.
+ *
+ *
+ * Unlike traditional combinations of these operators, `ReplayingShare` caches the last emitted
+ * value from the upstream observable or flowable *only* when one or more downstream subscribers
+ * are connected. This allows expensive upstream sources to be shut down when no one is listening
+ * while also replaying the last value seen by *any* subscriber to new ones.
+ *
+ * This one differs from https://github.com/JakeWharton/RxReplayingShare in that it will no longer
+ * share a value from a finalized Rx stream, i.e. it erases the last seen cached value when
+ * the upstream finalizes.
+ */
+class ReplayingUnfinalizedShare<T> private constructor() : ObservableTransformer<T, T>, FlowableTransformer<T, T> {
+
+    override fun apply(upstream: Observable<T>): Observable<T> {
+        val lastSeen = LastSeen<T>()
+        return LastSeenObservable(
+                upstream.doFinally(lastSeen).doOnNext(lastSeen).share(),
+                lastSeen
+        )
+    }
+
+    override fun apply(upstream: Flowable<T>): Flowable<T> {
+        val lastSeen = LastSeen<T>()
+        return LastSeenFlowable(
+                upstream.doFinally(lastSeen).doOnNext(lastSeen).share(),
+                lastSeen
+        )
+    }
+
+    internal class LastSeen<T> : Consumer<T>, Action {
+        @Volatile
+        var value: T? = null
+
+        override fun accept(latest: T) {
+            value = latest
+        }
+
+        override fun run() {
+            value = null
+        }
+    }
+
+    private class LastSeenObservable<T>(private val upstream: Observable<T>, private val lastSeen: LastSeen<T>) : Observable<T>() {
+
+        override fun subscribeActual(observer: Observer<in T>) {
+            upstream.subscribe(LastSeenObserver(observer, lastSeen))
+        }
+    }
+
+    private class LastSeenObserver<T>(private val downstream: Observer<in T>, private val lastSeen: LastSeen<T>) : Observer<T> {
+
+        override fun onSubscribe(d: Disposable) {
+            downstream.onSubscribe(d)
+
+            val value = lastSeen.value
+            if (value != null) {
+                downstream.onNext(value)
+            }
+        }
+
+        override fun onNext(value: T) {
+            downstream.onNext(value)
+        }
+
+        override fun onComplete() {
+            downstream.onComplete()
+        }
+
+        override fun onError(e: Throwable) {
+            downstream.onError(e)
+        }
+    }
+
+    private class LastSeenFlowable<T>(private val upstream: Flowable<T>, private val lastSeen: LastSeen<T>) : Flowable<T>() {
+
+        override fun subscribeActual(subscriber: Subscriber<in T>) {
+            upstream.subscribe(LastSeenSubscriber(subscriber, lastSeen))
+        }
+    }
+
+    private class LastSeenSubscriber<T>(private val downstream: Subscriber<in T>, private val lastSeen: LastSeen<T>) : Subscriber<T>, Subscription {
+        private var subscription: Subscription? = null
+        private var first = true
+
+        override fun onSubscribe(subscription: Subscription) {
+            this.subscription = subscription
+            downstream.onSubscribe(this)
+        }
+
+        override fun request(amount: Long) {
+            @Suppress("NAME_SHADOWING")
+            var amount = amount
+
+            if (amount == 0L) return
+
+            if (first) {
+                first = false
+
+                val value = lastSeen.value
+                if (value != null) {
+                    downstream.onNext(value)
+
+                    if (amount != java.lang.Long.MAX_VALUE && --amount == 0L) {
+                        return
+                    }
+                }
+            }
+            subscription?.request(amount)
+        }
+
+        override fun cancel() {
+            subscription?.cancel()
+        }
+
+        override fun onNext(value: T) {
+            downstream.onNext(value)
+        }
+
+        override fun onComplete() {
+            downstream.onComplete()
+        }
+
+        override fun onError(t: Throwable) {
+            downstream.onError(t)
+        }
+    }
+
+    companion object {
+        private val INSTANCE = ReplayingUnfinalizedShare<Any>()
+
+        /** The singleton instance of this transformer.  */
+        fun <T> instance(): ReplayingUnfinalizedShare<T> {
+            @Suppress("UNCHECKED_CAST")
+            return INSTANCE as ReplayingUnfinalizedShare<T>
+        }
+    }
+}


### PR DESCRIPTION
Fixed issues with sharing the RxBleConnection and modified and added unit-tests for this.

The main issue was with the `ReplayingShare` class, that kept sharing disconnected RxBleConnections. I added a `ReplayingUnfinalizedShare` to stops sharing the last emitted value when the upstream was finalized.

In addition, some other changes were added: Slight rewrite of connection-failure retries and using `Observable.defer` when obtaining a connection from the RxAndroidBle device.

This probably needs more testing, but I think it is a good start. Let me know :)
