### PR TITLE
Fix value out of range crash

### DIFF
--- a/library/src/main/kotlin/io/intrepid/bleidiom/BleTransformers.kt
+++ b/library/src/main/kotlin/io/intrepid/bleidiom/BleTransformers.kt
@@ -45,7 +45,7 @@ internal fun fixCustomUUID(uuid: String) = when (uuid.length) {
 /**
  * Gets the [ByteArray] version of a [String] MAC-address.
  */
-val String.macAddress get() = ByteArray(6) { substring(it * 3, it * 3 + 2).toByte(16) }
+val String.macAddress get() = ByteArray(6) { substring(it * 3, it * 3 + 2).toShort(16).toPositiveInt().toByte() }
 
 /**
  * Gets the [String] version of a [ByteArray] MAC-address.

--- a/library/src/main/kotlin/io/intrepid/bleidiom/BleTransformers.kt
+++ b/library/src/main/kotlin/io/intrepid/bleidiom/BleTransformers.kt
@@ -45,7 +45,7 @@ internal fun fixCustomUUID(uuid: String) = when (uuid.length) {
 /**
  * Gets the [ByteArray] version of a [String] MAC-address.
  */
-val String.macAddress get() = ByteArray(6) { substring(it * 3, it * 3 + 2).toShort(16).toPositiveInt().toByte() }
+val String.macAddress get() = ByteArray(6) { (substring(it * 3, it * 3 + 2).toInt(16) and 0x000000FF).toByte() }
 
 /**
  * Gets the [String] version of a [ByteArray] MAC-address.

--- a/library/src/test/kotlin/io/intrepid/bleidiom/BleTransformersTest.kt
+++ b/library/src/test/kotlin/io/intrepid/bleidiom/BleTransformersTest.kt
@@ -6,7 +6,9 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.powermock.modules.junit4.PowerMockRunner
+import java.util.*
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 @Suppress("FunctionName")
 @RunWith(PowerMockRunner::class)
@@ -39,5 +41,12 @@ class BleTransformersTest {
     fun test_fix_sign_for_ints_unsigned() {
         assertEquals(1, 1.toPositiveLong())
         assertEquals(4294967295, (-1).toPositiveLong())
+    }
+
+    @Test
+    fun test_String_macAddress_returns_correct_byte_array_for_0_to_255_range() {
+        val macAddress = "AF:0F:01:af:Af:aF"
+        val expectedMacAddressByteArray = byteArrayOf(175.toByte(), 15, 1, 175.toByte(), 175.toByte(), 175.toByte())
+        assertTrue(Arrays.equals(expectedMacAddressByteArray, macAddress.macAddress))
     }
 }


### PR DESCRIPTION
When converting the mac address from String to byte[], I faced value out of range crash.

This crash happened when value of byte in mac address was > 127. eg. in mac address "AF:00:00:00:00:00", AF translates to 172 in decimal. We want to assign it to Byte.
The problem was that the String.toByte() extension was expecting signed byte(-128 to 127) and did throw exception if value was not in that range.
To resolve the problem, I first used the String.toShort() extension so that the sign bit is not a problem. So, bytes in mac address like "AF" become "175" and then I used custom extension already defined in the BleTransformer.kt to convert it to Byte which is unsigned Byte.